### PR TITLE
fix test suite

### DIFF
--- a/controldev_websocket.orogen
+++ b/controldev_websocket.orogen
@@ -1,20 +1,22 @@
-name 'controldev_websocket'
+# frozen_string_literal: true
 
-using_library 'controldev'
-using_library 'base-logging'
-using_library 'jsoncpp', typekit: false
+name "controldev_websocket"
 
-import_types_from 'base'
-import_types_from 'controldev/RawCommand.hpp'
-import_types_from 'controldev_websocketTypes.hpp'
+using_library "controldev"
+using_library "base-logging"
+using_library "jsoncpp", typekit: false
 
-task_context 'Task' do
-    property 'port', 'uint16_t', 58000
-    property 'axis_map', '/std/vector</controldev_websocket/Mapping>'
-    property 'button_map', '/std/vector</controldev_websocket/ButtonMapping>'
+import_types_from "base"
+import_types_from "controldev/RawCommand.hpp"
+import_types_from "controldev_websocketTypes.hpp"
 
-    output_port 'raw_command', 'controldev/RawCommand'
-    output_port 'statistics', 'controldev_websocket/Statistics'
+task_context "Task" do
+    property "port", "uint16_t", 58_000
+    property "axis_map", "/std/vector</controldev_websocket/Mapping>"
+    property "button_map", "/std/vector</controldev_websocket/ButtonMapping>"
+
+    output_port "raw_command", "controldev/RawCommand"
+    output_port "statistics", "controldev_websocket/Statistics"
 
     periodic 0.1
 end

--- a/controldev_websocketTypes.hpp
+++ b/controldev_websocketTypes.hpp
@@ -23,13 +23,13 @@ namespace controldev_websocket
 
     struct ButtonMapping: public Mapping
     {
-        double threshold;
+        double threshold = 0.5;
     };
 
     struct Statistics
     {
-        int errors;
-        int received;
+        int errors = 0;
+        int received = 0;
         base::Time time;
     };
 } // end namespace controldev_websocket

--- a/manifest.xml
+++ b/manifest.xml
@@ -12,4 +12,5 @@ Finally, for each received message the server (task) sends a message back to its
   <depend package="base/logging"/>
 
   <test_depend name="tools/syskit" />
+  <test_depend name="kontena-websocket-client" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -148,22 +148,22 @@ bool Task::handleAskControlMessage() {
 
 // Fill the Raw Command with the JSON data at decoder.
 bool Task::updateRawCommand(){
-    try{
-        for (uint i = 0; i < axis->size(); ++i){
+    try {
+        for (uint i = 0; i < axis->size(); ++i) {
             raw_cmd_obj.axisValue.at(i) = decoder->getValue(axis->at(i));
         }
         for (uint i = 0; i < button->size(); ++i){
-            raw_cmd_obj.buttonValue.at(i) = decoder->getValue(button->at(i))
-                                                              > button->at(i).threshold;
+            raw_cmd_obj.buttonValue.at(i) =
+                decoder->getValue(button->at(i)) > button->at(i).threshold;
         }
-
-    // A failure here means that the client sent a bad message or the mapping isn't good.
-    // Just inform the client: return false.
-    } catch (const std::exception &e){
+        return true;
+    }
+    // A failure here means that the client sent a bad message or the
+    // mapping isn't good. Just inform the client: return false.
+    catch (const std::exception &e) {
         LOG_ERROR_S << "Invalid message, got error: " << e.what() << std::endl;
         return false;
     }
-    return true;
 }
 
 Task::Task(std::string const& name, TaskCore::TaskState initial_state)

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -6,9 +6,11 @@
 
 #include <seasocks/PrintfLogger.h>
 #include <seasocks/Server.h>
+#include <seasocks/WebSocket.h>
 
 #include <string.h>
 #include <iostream>
+#include <json/json.h>
 
 using namespace controldev_websocket;
 using namespace controldev;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -98,7 +98,14 @@ struct controldev_websocket::MessageDecoder{
     }
 
     double getValue(const Mapping &mapping){
-        return jdata[mapFieldName(mapping.type)][mapping.index].asDouble();
+        auto const& field = jdata[mapFieldName(mapping.type)];
+        if (!field.isValidIndex(mapping.index)) {
+            throw std::out_of_range(
+                "incoming raw command does not have a field " +
+                std::to_string(mapping.index) + "in " + mapFieldName(mapping.type)
+            );
+        }
+        return field[mapping.index].asDouble();
     }
 };
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -112,13 +112,9 @@ bool Task::handleIncomingWebsocketMessage(char const* data, WebSocket *connectio
     if (is_controlling) {
         return handleControlMessage();
     }
-
-    if (!handleAskControlMessage()){
-        connection->close();
-        return false;
+    else {
+        return handleAskControlMessage();
     }
-
-    return true;
 }
 
 bool Task::handleControlMessage() {

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -35,27 +35,27 @@ namespace controldev_websocket{
      */
     class Task : public TaskBase
     {
-    friend class TaskBase;
-    friend struct JoystickHandler;
+        friend class TaskBase;
+        friend struct JoystickHandler;
 
-    MessageDecoder *decoder = nullptr;
+        MessageDecoder *decoder = nullptr;
 
-    seasocks::Server *server = nullptr;
-    std::thread *thread = nullptr;
-    std::shared_ptr<JoystickHandler> handler;
-    controldev::RawCommand raw_cmd_obj;
-    bool handleIncomingWebsocketMessage(char const* data, seasocks::WebSocket *connection);
-    bool updateRawCommand();
-    bool handleAskControlMessage();
-    bool handleControlMessage();
+        seasocks::Server *server = nullptr;
+        std::thread *thread = nullptr;
+        std::shared_ptr<JoystickHandler> handler;
+        controldev::RawCommand raw_cmd_obj;
+        bool handleIncomingWebsocketMessage(char const* data, seasocks::WebSocket *connection);
+        bool updateRawCommand();
+        bool handleAskControlMessage();
+        bool handleControlMessage();
 
 
-    std::vector<Mapping> *axis = nullptr;
-    std::vector<ButtonMapping> *button = nullptr;
+        std::vector<Mapping> *axis = nullptr;
+        std::vector<ButtonMapping> *button = nullptr;
 
-    bool is_controlling = false;
-    int errors = 0;
-    int received = 0;
+        bool is_controlling = false;
+        int errors = 0;
+        int received = 0;
 
     public:
         /** TaskContext constructor for Task

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -3,17 +3,17 @@
 #ifndef CONTROLDEV_WEBSOCKET_TASK_TASK_HPP
 #define CONTROLDEV_WEBSOCKET_TASK_TASK_HPP
 
-#include "../controldev_websocketTypes.hpp"
 #include "controldev_websocket/TaskBase.hpp"
 #include <controldev/RawCommand.hpp>
 
 #include <vector>
-#include <seasocks/Server.h>
-#include <seasocks/WebSocket.h>
 #include <thread>
 #include <memory>
 
-#include <json/json.h>
+namespace seasocks {
+    class WebSocket;
+    class Server;
+}
 
 namespace controldev_websocket{
     struct JoystickHandler;


### PR DESCRIPTION
The test suite had a lot of common boilerplate that made it hard to read. The refactoring of the
test suite itself is mainly factoring out of common patterns.

Moreover,
- the `state.received_messages` was used in a non-thread safe way
- the `has_error`/`state` fields were basically duplicating the built-in thread state tracking. Leverage the latter to remove the former - and this way get exceptions reported for better debugging.