### PR TITLE
fix: controldev_websocket would forever reject new connections if a handshake failed ever happened

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -34,7 +34,6 @@ struct controldev_websocket::JoystickHandler : WebSocket::Handler {
     Client controlling;
     uint16_t connection_id = 0;
     Task* task = nullptr;
-    Json::Value msg;
     Json::FastWriter fast;
     Statistics statistic;
 
@@ -89,12 +88,15 @@ struct controldev_websocket::JoystickHandler : WebSocket::Handler {
                 LOG_WARN_S << "Control given to the id " << controlling.id << std::endl;
                 return;
             }
+
             LOG_WARN_S << "Handshake with id " << pending.id << " failed" << std::endl;
+            Json::Value msg;
             msg["connection_state"]["state"] = "handshake failed";
             socket->send(fast.write(msg));
             return;
         }
         result = result && task->handleControlMessage();
+        Json::Value msg;
         msg["result"] = result;
         ++task->m_statistics.received;
 


### PR DESCRIPTION
msg was unnecessarily defined at the class level. This meant that whatever data that has ever been written on it would always stick and stay there forever.

In practice, only the handshake failed connection state would cause this. We would have to kill the whole component whenever this situation happens.