### PR TITLE
feat: handle the server thread unexpectedly terminating

### DIFF
--- a/examples/gamepad.js
+++ b/examples/gamepad.js
@@ -35,18 +35,37 @@ function formatGamepadState(gamepad) {
 }
 
 function createGamepadWatch() {
+    let lastTimestamps = [];
     window.setInterval(function() {
         body = document.body;
+
+        let changed = false;
+        for (let i = 0; i < navigator.getGamepads().length; ++i) {
+            let gamepad = navigator.getGamepads()[i];
+            let timestamp;
+            if (gamepad) {
+                timestamp = gamepad.timestamp;
+            }
+
+            changed = changed || lastTimestamps[i] !== timestamp;
+        }
+
+        if (!changed) {
+            return;
+        }
+
         document.body.innerHTML = "";
         for (let i = 0; i < navigator.getGamepads().length; ++i) {
             let gamepad = navigator.getGamepads()[i];
             if (gamepad !== null) {
                 body.appendChild(formatGamepadState(gamepad))
+                lastTimestamps[i] = gamepad.timestamp;
             }
             else {
                 gamepad_info = document.createElement("div");
                 gamepad_info.innerHTML = `Gamepad [${i}] is null`
                 body.appendChild(gamepad_info)
+                lastTimestamps[i] = undefined;
             }
         }
     }, 100)

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -7,6 +7,7 @@
 #include <base/Float.hpp>
 #include <controldev/RawCommand.hpp>
 
+#include <future>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -45,8 +46,8 @@ namespace controldev_websocket {
 
         MessageDecoder* decoder = nullptr;
 
-        seasocks::Server* server = nullptr;
-        std::thread* thread = nullptr;
+        seasocks::Server *server = nullptr;
+        std::future<void> server_thread;
         controldev::RawCommand raw_cmd_obj;
         bool parseIncomingWebsocketMessage(char const* data,
             seasocks::WebSocket* connection);


### PR DESCRIPTION
This is a PR I was sitting on for a while. It makes sure we create the server object on the same thread it operates, and can detect that it quits.

Right now, tests do not pass without this change, with or without the patch to Syskit that discovered it. I believe the Syskit patch is only causing the package to be built and tested.