### PR TITLE
fix: condition under which we attempt to close the websocket in tests

### DIFF
--- a/test/web_socket_task_test.rb
+++ b/test/web_socket_task_test.rb
@@ -63,7 +63,7 @@ describe OroGen.controldev_websocket.Task do
 
     after do
         @websocket_created.each do |s|
-            s.ws.close(10) if s.ws.connected?
+            s.ws.close(10) if s.ws.open?
             flunk("connection thread failed to quit") unless s.connection_thread.join(10)
         end
     end


### PR DESCRIPTION
This randomly fails as connected? may be true even if the connection is closed, if the websocket isn't completely closed yet.